### PR TITLE
Make default number of threads number of cores if 'threads' is not defined.

### DIFF
--- a/multithread.js
+++ b/multithread.js
@@ -10,7 +10,7 @@
 	}
 
 	function Multithread(threads) {
-		this.threads = Math.max((typeof threads !== 'undefined') ? threads: (typeof navigator.hardwareConcurrency !== 'undefined') ? navigator.hardwareConcurrency : 2);
+		this.threads = (typeof threads !== 'undefined') ? threads: (typeof navigator.hardwareConcurrency !== 'undefined') ? navigator.hardwareConcurrency : 2
 		this._queue = [];
 		this._queueSize = 0;
 		this._activeThreads = 0;

--- a/multithread.js
+++ b/multithread.js
@@ -10,7 +10,7 @@
 	}
 
 	function Multithread(threads) {
-		this.threads = Math.max(2, threads | 0);
+		this.threads = Math.max(2, threads | 0, navigator.hardwareConcurrency | 0);
 		this._queue = [];
 		this._queueSize = 0;
 		this._activeThreads = 0;

--- a/multithread.js
+++ b/multithread.js
@@ -10,7 +10,7 @@
 	}
 
 	function Multithread(threads) {
-		this.threads = Math.max(2, threads | 0, navigator.hardwareConcurrency | 0);
+		this.threads = Math.max((typeof threads !== 'undefined') ? threads: (typeof navigator.hardwareConcurrency !== 'undefined') ? navigator.hardwareConcurrency : 2);
 		this._queue = [];
 		this._queueSize = 0;
 		this._activeThreads = 0;


### PR DESCRIPTION
This change will make the default number of threads the number of threads avaliable if the browser supports it, which I thought would simplify with what @keithwhor said in the README:

> Multithread will provide the best results when num_threads **matches the processor core count** of the computer you're using, but 2-4 threads should always be reasonably speedy.
